### PR TITLE
zeromq: enable drafts

### DIFF
--- a/Formula/z/zeromq.rb
+++ b/Formula/z/zeromq.rb
@@ -50,7 +50,7 @@ class Zeromq < Formula
     # https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454177261
 
     system "./autogen.sh" if build.head?
-    system "./configure", "--with-libsodium", *std_configure_args
+    system "./configure", "--with-libsodium", "--enable-drafts", *std_configure_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Enables the draft API for libzmq. While this might sound like an experimental feature, it really isn't anymore at this point: libzmq development has stalled, and the draft API includes essential features such as a poller and hasn't changed in years (see https://github.com/zeromq/libzmq/issues/4164 and https://github.com/zeromq/libzmq/issues/4658 for example). There are various software frameworks which require the draft API (e.g. ROOT (https://root.cern/), `root` in hombrew-core).

This also has no impact on existing programs using zeromq since it does not change the existing API, it just exposes new functions.